### PR TITLE
Update matcher_test.go

### DIFF
--- a/pkg/muxer/tcp/matcher_test.go
+++ b/pkg/muxer/tcp/matcher_test.go
@@ -133,6 +133,12 @@ func Test_HostSNI(t *testing.T) {
 			serverName: "foo.example.com",
 			match:      true,
 		},
+		{
+			desc:       "Matching hosts with subdomains with _",
+			rule:       "HostSNI(`foo_bar.example.com`)",
+			serverName: "foo_bar.example.com",
+			match:      true,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
test for subdomain with _ in name
 missing test 